### PR TITLE
Bug: FixUnits deletes the background of the power screen.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ Fixes how units, such as kW, are displayed. Power is now measured in kW instead 
 Oxygen no longer stops at ppm, and is now displayed as a percentage once it reaches 1,000 ppm. Earth is 21% oxygen, if you want a target to aim for.
 All values are now displayed with thousand separators (commas), except in the build menu.
 
+Bug: The mod deletes the semi-transparent grey background of the power screen.
+
 # Mod Installation
 
 Installation is manual, and instructions are currently the same for every mod.


### PR DESCRIPTION
Hi. Sorry to bother you this way (as there is no Issues tab in your repo).

We've been trying to help a player using your FixUnits mod who run into a bug with it: the semi-transparent grey background is deleted, making it difficult to see the actual screen.

https://discord.com/channels/635441508694097921/882722354722127882/993943256066969631

Game version 0.4.015.

Could you look into it?